### PR TITLE
Active artifacts for yonFarmInfo

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Contact any of the following published endpoints through a browser or code.
 - **Get CSV-formatted farm overview:**  
   [`/yonFarmInfo?EID=EIxxxx`](https://ei_worker.tylertms.workers.dev/yonFarmInfo?EID=EIxxxx)  
 - **Get active earning/laying buffs for a given coop**  
-  [`coop_buffs?EID=EIxxx&contract=KEV-ID&coop=COOP-NAME`](https://ei_worker.tylertms.workers.dev/coop_buff?EID=EIxxxx&contract=KEV-ID&coop=COOP-NAME)
+  [`/coop_buffs?EID=EIxxxx&contract=KEV-ID&coop=COOP-NAME`](https://ei_worker.tylertms.workers.dev/coop_buffs?EID=EIxxxx&contract=KEV-ID&coop=COOP-NAME)
   - *If the EID making the call is found in the coop, its buffs will be excluded.*
 - **Get current contracts and events (periodicals):**  
   [`/periodicals?EID=EIxxxx`](https://ei_worker.tylertms.workers.dev/periodicals?EID=EIxxxx)  

--- a/handlers/active_missions.js
+++ b/handlers/active_missions.js
@@ -29,8 +29,8 @@ async function handle(request, context) {
 
         const text = await response.text();
         const authRespMessage = context.proto.AuthenticatedMessage.deserializeBinary(text).toObject();
-        const lbresp = context.proto.GetActiveMissionsResponse.deserializeBinary(authRespMessage.message);
-        const string = JSON.stringify(lbresp.toObject());
+        const activeMissionsResp = context.proto.GetActiveMissionsResponse.deserializeBinary(authRespMessage.message);
+        const string = JSON.stringify(activeMissionsResp.toObject());
 
         return new Response(string);
     } catch (error) {

--- a/handlers/afx_config.js
+++ b/handlers/afx_config.js
@@ -23,8 +23,8 @@ async function handle(request, context) {
 
 		const text = await response.text();
 		const authMessage = context.proto.AuthenticatedMessage.deserializeBinary(text).toObject().message;
-		const fcresp = context.proto.ArtifactsConfigurationResponse.deserializeBinary(authMessage);
-		const string = JSON.stringify(fcresp.toObject());
+		const artiConfigResp = context.proto.ArtifactsConfigurationResponse.deserializeBinary(authMessage);
+		const string = JSON.stringify(artiConfigResp.toObject());
 
 		return new Response(string);
 	} catch (error) {

--- a/handlers/leaderboard_info.js
+++ b/handlers/leaderboard_info.js
@@ -6,9 +6,9 @@ async function handle(request, context) {
 
 		const text = await response.text();
 		const authMessage = context.proto.AuthenticatedMessage.deserializeBinary(text).toObject().message;
-		const lbresp = context.proto.LeaderboardInfo.deserializeBinary(authMessage);
+		const lbInfoResp = context.proto.LeaderboardInfo.deserializeBinary(authMessage);
 
-		const string = JSON.stringify(lbresp.toObject());
+		const string = JSON.stringify(lbInfoResp.toObject());
 
 		return new Response(string);
 	} catch (error) {

--- a/handlers/season_info.js
+++ b/handlers/season_info.js
@@ -6,8 +6,8 @@ async function handle(request, context) {
 
 		const text = await response.text();
 		const authMessage = context.proto.AuthenticatedMessage.deserializeBinary(text).toObject();
-		const lbresp = context.proto.ContractSeasonInfos.deserializeBinary(authMessage.message);
-		const string = JSON.stringify(lbresp.toObject());
+		const seasonInfoResp = context.proto.ContractSeasonInfos.deserializeBinary(authMessage.message);
+		const string = JSON.stringify(seasonInfoResp.toObject());
 
 		return new Response(string);
 	} catch (error) {

--- a/handlers/sub_status.js
+++ b/handlers/sub_status.js
@@ -8,9 +8,9 @@ async function handle(request, context) {
 
 		const text = await response.text();
 		const authMessage = context.proto.AuthenticatedMessage.deserializeBinary(text).toObject().message;
-		const lbresp = context.proto.UserSubscriptionInfo.deserializeBinary(authMessage);
+		const subStatusResp = context.proto.UserSubscriptionInfo.deserializeBinary(authMessage);
 
-		const string = JSON.stringify(lbresp.toObject());
+		const string = JSON.stringify(subStatusResp.toObject());
 
 		return new Response(string);
 	} catch (error) {

--- a/handlers/yonFarmInfo.js
+++ b/handlers/yonFarmInfo.js
@@ -126,16 +126,20 @@ async function handle(request, context) {
 			for (let j = 0; j < backup.farmsList.length; j++) {
 				tempLine += backup.farmsList[j].commonResearchList[i].level + ",";
 			}
-			if (i < boostIds.length) {
-				const commaCount = (tempLine.match(/,/g) || []).length; 
-				if (commaCount < 10) {
-					tempLine = tempLine.padEnd(tempLine.length + (10 - commaCount), ",");
-				}
+			const commaCount = (tempLine.match(/,/g) || []).length; 
+			// Pad to ensure boosts and artifacts sections are in the same place always (horizontally at least)
+			if (commaCount < 10) {
+				tempLine = tempLine.padEnd(tempLine.length + (10 - commaCount), ",");
+			}
+			if (i < boostIds.length) { // Assume there will always be less boosts than common research items
 				tempLine += boostIds[i] + ","
 				const boost = backup.game.boostsList.find(boost => boost.boostId === boostIds[i]);
 				tempLine += (boost ? boost.count : "0") + ",";
+			} else {
+				// If we are out of boosts to add, add empty values to ensure the artifacts section remains in the same place
+				tempLine += ",,";
 			}
-			if (i < activeArtifactsSection.length) {
+			if (i < activeArtifactsSection.length) { // Assume there will always be less artifacts than common research items
 				const artifactLine = activeArtifactsSection[i];
 				if (artifactLine) {
 					tempLine += artifactLine;

--- a/handlers/yonFarmInfo.js
+++ b/handlers/yonFarmInfo.js
@@ -1,4 +1,13 @@
-const { bigNumberToString, convertGrade, getEggName, getDimension, getBuffLevel } = require("../utils/tools");
+const {
+	bigNumberToString,
+	convertGrade,
+	getEggName,
+	getDimension,
+	getBuffLevel,
+	getArtifactName,
+	getArtifactRarity,
+	getArtifactLevel
+} = require("../utils/tools");
 const { handle: handleBackup } = require("./backup");
 const { handle: handlePeriodicals } = require('./periodicals');
 
@@ -69,6 +78,47 @@ async function handle(request, context) {
 		backup.farmsList.forEach(farm => {
 			csv += bigNumberToString(farm.cashEarned - farm.cashSpent, 3) + ",";
 		})
+
+		// Not a very neat implementation (compared to Tiller's work in this file), but it works ;)
+		// This is also here because Yon didn't want it added on the bottom, but rather to the side of exsisting data
+		const activeArtifactsSection = ["Farm,ArtifactType,ArtifactRarity,ArtifactTier,Stone1,Stone2,Stone3,"];
+
+		for (const farm of backup.farmsList) {
+			let farmIndex = 0;
+			if (farm.contractId) {
+				farmIndex = backup.farmsList.findIndex(
+					(c) => c.contractId === farm.contractId
+				);
+			} else {
+				farmIndex = backup.farmsList.findIndex((c) => c.farmType === 2);
+			}
+
+			const mappedArtis = (
+				backup.artifactsDb.activeArtifactSetsList[farmIndex]?.slotsList ?? []
+			).map((slot) => {
+				return backup.artifactsDb.inventoryItemsList.find(
+					(i) => i.itemId === slot.itemId
+				);
+			});
+
+			const farmName = farm.contractId ? farm.contractId : "Home";
+
+			for (let artifact of mappedArtis) {
+				if (!artifact) continue; // For empty slots (no artifact(s) equipped)
+				artifact = artifact.artifact;
+				const artifactName = getArtifactName(artifact.spec.name);
+				const artifactRarity = getArtifactRarity(artifact.spec.rarity);
+				const artifactLevel = getArtifactLevel(artifact.spec.level);
+				let stones = "";
+				for (const stone of artifact.stonesList) {
+					const stoneName = getArtifactName(stone.name);
+					const stoneLevel = parseInt(stone.level) + 2;
+					stones += stoneName + "_" + stoneLevel + ",";
+				}
+				activeArtifactsSection.push(`${farmName},${artifactName},${artifactRarity},${artifactLevel},` + stones + "\n");
+			}
+		}
+	
 		csv = csv.slice(0, -1) + "\n";
 		for (let i = 0; i < backup.farmsList[0].commonResearchList.length; i++) {
 			let tempLine = "";
@@ -84,6 +134,12 @@ async function handle(request, context) {
 				tempLine += boostIds[i] + ","
 				const boost = backup.game.boostsList.find(boost => boost.boostId === boostIds[i]);
 				tempLine += (boost ? boost.count : "0") + ",";
+			}
+			if (i < activeArtifactsSection.length) {
+				const artifactLine = activeArtifactsSection[i];
+				if (artifactLine) {
+					tempLine += artifactLine;
+				}
 			}
 			tempLine = tempLine.slice(0, -1) + "\n";
 			csv += tempLine

--- a/utils/tools.js
+++ b/utils/tools.js
@@ -1,3 +1,5 @@
+const proto = require('../ei_pb');
+
 function bigNumberToString(number, decimals, strLen) {
     var letters = {
         0: '', 3: 'k', 6: 'M', 9: 'B', 12: 'T', 15: 'q', 18: 'Q', 21: 's',
@@ -42,50 +44,11 @@ function convertGrade(gradeId) {
 }
 
 function getEggName(num) {
-    switch (num) {
-        case 1: return "EDIBLE";
-        case 2: return "SUPERFOOD";
-        case 3: return "MEDICAL";
-        case 4: return "ROCKET_FUEL";
-        case 5: return "SUPER_MATERIAL";
-        case 6: return "FUSION";
-        case 7: return "QUANTUM";
-        case 8: return "IMMORTALITY";
-        case 9: return "TACHYON";
-        case 10: return "GRAVITON";
-        case 11: return "DILITHIUM";
-        case 12: return "PRODIGY";
-        case 13: return "TERRAFORM";
-        case 14: return "ANTIMATTER";
-        case 15: return "DARK_MATTER";
-        case 16: return "AI";
-        case 17: return "NEBULA";
-        case 18: return "UNIVERSE";
-        case 19: return "ENLIGHTENMENT";
-        case 100: return "CHOCOLATE";
-        case 101: return "EASTER";
-        case 102: return "WATERBALLOON";
-        case 103: return "FIREWORK";
-        case 104: return "PUMPKIN";
-        case 200: return "CUSTOM";
-        default: return "UNKNOWN";
-    }
+    return getProtoNameFromEnum(proto.Egg, num);
 }
 
 function getDimension(num) {
-    switch (num) {
-        case 0: return "INVALID";
-        case 1: return "EARNINGS";
-        case 2: return "AWAY_EARNINGS";
-        case 3: return "INTERNAL_HATCHERY_RATE";
-        case 4: return "EGG_LAYING_RATE";
-        case 5: return "SHIPPING_CAPACITY";
-        case 6: return "HAB_CAPACITY";
-        case 7: return "VEHICLE_COST";
-        case 8: return "HAB_COST";
-        case 9: return "RESEARCH_COST";
-        default: return "UNKNOWN";
-    }
+    return getProtoNameFromEnum(proto.GameModifier.GameDimension, num);
 }
 
 function getBuffLevel(maxFarmReached) {
@@ -94,6 +57,26 @@ function getBuffLevel(maxFarmReached) {
     if (maxFarmReached >= 100000000) return 2;
     if (maxFarmReached >= 10000000) return 1;
     return NaN; // return NaN if no level has been reached
+}
+
+function getArtifactLevel(num) {
+    return getProtoNameFromEnum(proto.ArtifactSpec.Level, num);
+}
+
+/**
+ * Helper function
+ */
+function getProtoNameFromEnum(protoObject, enumValue) {
+    return Object.keys(protoObject).find(key => protoObject[key] === enumValue) || "UNKNOWN";
+}
+
+
+function getArtifactRarity(num) {
+    return getProtoNameFromEnum(proto.ArtifactSpec.Rarity, num);
+}
+
+function getArtifactName(num) {
+    return getProtoNameFromEnum(proto.ArtifactSpec.Name, num);
 }
 
 async function createAuthHash(message, env) {
@@ -110,4 +93,14 @@ async function createAuthHash(message, env) {
     return hashHex;
 }
 
-module.exports = { bigNumberToString, convertGrade, getEggName, getDimension, getBuffLevel, createAuthHash };
+module.exports = {
+	bigNumberToString,
+	convertGrade,
+	getEggName,
+	getDimension,
+	getBuffLevel,
+	createAuthHash,
+    getArtifactLevel,
+    getArtifactRarity,
+    getArtifactName
+};


### PR DESCRIPTION
Add active artifacts to the yonFarmInfo endpoint.
The CSV is now even more chaotic, Yon requested they'd be in a static place.
This implementation should work, regardless of the user's boost inventory.

Also tidied up some other handlers to be a bit clearer in variable names, and updated `get[..]Name()` functions to rely on the names of the proto, instead of hardcoding them.